### PR TITLE
Fixed: when run in a computer with less than ksplit processors 

### DIFF
--- a/polyssifier.py
+++ b/polyssifier.py
@@ -97,7 +97,7 @@ def make_classifiers(data_shape, ksplit):
         "Random Forest": RandomForestClassifier(max_depth=None,
                                                 n_estimators=10,
                                                 max_features='auto',
-                                                n_jobs=PROCESSORS/ksplit),
+                                                n_jobs=np.max([PROCESSORS/ksplit,1]),
         "Logistic Regression": LogisticRegression(),
         "Naive Bayes": GaussianNB(),
         "LDA": LDA()}


### PR DESCRIPTION
When a computer with 8 processors (as my laptop) tries to run the script, the RandomTree is set to use 0 processors and errors pops up. I set it to use 1 instead of 0 for this case.
